### PR TITLE
Set label index to -1 in case decision differs from the labels

### DIFF
--- a/uncover_json_writer/tool_json_writer.py
+++ b/uncover_json_writer/tool_json_writer.py
@@ -42,10 +42,14 @@ class Detector:
         raise NotImplementedError
 
     def label_index(self, label: str = None, labels: List[str] = None) -> int:
-        """Gives index of label. If label is not given, takes the internal decision."""
+        """Gives index of label. If label is not among the labels, returns -1."""
         label = self.decision if label is None else label
         labels = self.labels if labels is None else labels
         matching = [i for i, v in enumerate(labels) if v == label]
+
+        if len(matching) == 0:
+            return -1
+
         return matching[0]
 
 


### PR DESCRIPTION
Some tools can produce multiple matches. In theses cases, reporting a single decision might be misleading. An alternative could be to return a negative label index and a user-defined string as decision.
Right now, the writer fails silently when the label is not found within the labels.